### PR TITLE
Recognise project files with kebab-case names

### DIFF
--- a/server/src/MarkdownConfig.js
+++ b/server/src/MarkdownConfig.js
@@ -13,7 +13,7 @@ export default class MarkdownConfig {
 
   getOptions(uri) {
     const fileName = path.basename(uri);
-    if (fileName.startsWith("project_") || fileName.startsWith("project:")) {
+    if (fileName.startsWith("project_") || fileName.startsWith("project-")) {
       return this.#projectConfig;
     } else {
       return this.#lessonConfig;

--- a/server/src/MarkdownConfig.js
+++ b/server/src/MarkdownConfig.js
@@ -12,7 +12,8 @@ export default class MarkdownConfig {
   #lessonConfig;
 
   getOptions(uri) {
-    if (uri.includes("project_")) {
+    const fileName = path.basename(uri);
+    if (fileName.startsWith("project_") || fileName.startsWith("project:")) {
       return this.#projectConfig;
     } else {
       return this.#lessonConfig;
@@ -24,12 +25,12 @@ export default class MarkdownConfig {
       return;
     }
 
-    const paths = this.#getConfigFiles(uri)
+    const paths = this.#getConfigFiles(uri);
     if (paths == null) {
       return;
     }
 
-    const baseConfig = fs.readFileSync(paths.base).toString();;
+    const baseConfig = fs.readFileSync(paths.base).toString();
     const options = parse(baseConfig);
     const rulePromises = options.customRules.map(
       (r) => import(path.join(paths.fileUrl, r)),
@@ -70,7 +71,7 @@ export default class MarkdownConfig {
             fileUrl: pathToFileURL(dir).href,
             base: baseConfig,
             lesson: lessonConfig,
-            project: projectConfig
+            project: projectConfig,
           };
 
           return paths;


### PR DESCRIPTION
## Because

Unfortunately, not all lesson files use snake case, such as those in [`foundations/` in the curriculum repo](https://github.com/TheOdinProject/curriculum/tree/main/foundations) which use kebab case. The LSP needs to handle kebab case files as well as long as the curriculum still uses lesson/project files using it.

Tested working in Neovim.

## This PR

- Includes `project-` in project file detection
- Detects based on file name start (prevents extremely rare chance a full path somehow contains `project{_,-}` anywhere other than the start of the file name itself)
- Fixes formatting (now consistent with style across rest of codebase)